### PR TITLE
Fix/release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,40 +82,21 @@ jobs:
 
           git checkout .
           [ -d ./bls/lib/linux/ ] && rm -rf ./bls/lib/linux/
+          [ -d ./bls/lib/android/ ] && rm -rf ./bls/lib/android/
 
           make clean
 
           mkdir -p ./bls/lib/linux/
 
-          git status .
           make CXX=clang++
-
-          git status .
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-
-          git add ./bls/lib/linux/ -f && git commit -m "fix(release): added libs for linux" && git push
-         
-      - name: Build android
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        run: |
-          git pull && git checkout release
-          git submodule update --init --recursive
-
-          git checkout . 
-          [ -d ./bls/lib/android/ ] && rm -rf ./bls/lib/android/
-          make clean
-
-          mkdir -p ./bls/lib/android/
-
           make android
 
+          git status .
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          git add ./bls/lib/android/ -f && git commit -m "fix(release): added libs for android"  && git push
-
+          git add ./bls/lib/ -f && git commit -m "fix(release): added libs for linux/android" && git push
+         
   build-macos:
     runs-on: macos-latest
     needs: build-linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,7 @@ on:
       version:
         description: 'release/tag: vX.Y.Z'
         required: true
-env:
-  BRANCH_NAME: "release-${{ github.event.inputs.version }}"
+
 
 jobs:
   create-branch:
@@ -35,7 +34,7 @@ jobs:
 
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git push --set-upstream origin "$BRANCH_NAME"
+          git push --set-upstream origin release
 
   build-windows:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,16 +56,14 @@ jobs:
           msystem: MINGW64
           install: base-devel git gcc make python3 # mingw-w64-x86_64-clang
 
-      - name: Checkout branch
+      - name: Build windows
         shell: msys2 {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
           git pull && git checkout release && git pull
           git submodule update --init --recursive
 
-      - name: Build windows
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        run: |
           gcc --version
           python3 --version
           make clean
@@ -111,15 +109,13 @@ jobs:
         with:
           ndk-version: r21d
 
-      - name: Checkout branch
-        run: |
-          git pull && git checkout release && git pull
-          git submodule update --init --recursive
-
       - name: Build linux
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
+          git pull && git checkout release && git pull
+          git submodule update --init --recursive
+          
           sudo apt install nasm
           make clean
           make CXX=clang++
@@ -134,6 +130,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
+          git pull && git checkout release && git pull
+          git submodule update --init --recursive
+
           make clean
           make android
 
@@ -155,15 +154,13 @@ jobs:
         with:
           go-version: ^1.20
 
-      - name: Checkout branch
-        run: |
-          git pull && git checkout release && git pull
-          git submodule update --init --recursive
-
       - name: Build darwin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
+          git pull && git checkout release && git pull
+          git submodule update --init --recursive
+
           brew install nasm
           make clean
           make
@@ -178,6 +175,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
+          git pull && git checkout release && git pull
+          git submodule update --init --recursive
+
           make clean
 
           git config user.name github-actions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git pull && git checkout release && git pull
+          git pull && git checkout release
           git submodule update --init --recursive
 
           gcc --version
@@ -120,7 +120,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git pull && git checkout release && git pull
+          git pull && git checkout release
           git submodule update --init --recursive
           
           sudo apt install nasm
@@ -139,7 +139,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git pull && git checkout release && git pull
+          git pull && git checkout release
           git submodule update --init --recursive
 
           [ -d ./bls/lib/android/ ] && rm -rf ./bls/lib/android/
@@ -169,7 +169,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git pull && git checkout release && git pull
+          git pull && git checkout release
           git submodule update --init --recursive
 
           brew install nasm
@@ -189,7 +189,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git pull && git checkout release && git pull
+          git pull && git checkout release
           git submodule update --init --recursive
 
           [ -d ./bls/lib/ios ] && rm -rf ./bls/lib/ios
@@ -218,7 +218,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git pull && git checkout release && git pull
+          git pull && git checkout release
           git submodule update --init --recursive
           git branch -av
           git rev-parse HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
           make clean
 
           mkdir -p ./bls/lib/linux/
+          mkdir -p ./bls/lib/android/
 
           make CXX=clang++
           make android
@@ -92,6 +93,7 @@ jobs:
           git config user.email github-actions@github.com
 
           git add ./bls/lib/ -f 
+          git checkout . 
           git status . -s | grep "M\|A" && git commit -m "fix(release): added libs for linux/android" && git push
          
   build-macos:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
 
           git add ./bls/lib/linux -f 
           git checkout . 
-          git status . -s | grep "M\|A" && git commit -m "fix(release): added libs for linux" && git push
+          git status . -s | grep "M\|A" | wc -l && git commit -m "fix(release): added libs for linux" && git push
 
       - name: Build android
         env:
@@ -113,7 +113,7 @@ jobs:
 
           git add ./bls/lib/android/ -f 
           git checkout . 
-          git status . -s | grep "M\|A" && git commit -m "fix(release): added libs for android" && git push
+          git status . -s | grep "M\|A" | wc -l && git commit -m "fix(release): added libs for android" && git push
                   
 
   build-macos:
@@ -137,7 +137,6 @@ jobs:
 
           brew install nasm
 
-          git checkout . 
           [ -d ./bls/lib/darwin/ ] && rm -rf ./bls/lib/darwin/
           make clean
 
@@ -148,10 +147,13 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           
-          rm -rf ./obj
-          git restore ./src/bls
+          git add ./bls/lib/darwin/ -f 
 
-          git add ./bls/lib/darwin/ -f && git commit -m "fix(release): added libs for darwin"  && git push
+          changes=$(git diff --staged --numstat | wc -l)
+          if [[ $changes -gt 0 ]]
+          then
+            git commit -m "fix(release): added libs for darwin"  && git push
+          fi
 
       - name: Build ios
         env:
@@ -172,18 +174,13 @@ jobs:
           git config user.email github-actions@github.com
 
           make ios
-
-          rm -rf ./obj
-          git restore ./src/bls
-
-          git add ./bls/lib/ios -f && git commit -m "fix(release): added libs for ios"  && git push
-
           make ios_simulator
 
-          rm -rf ./obj
-          git restore ./src/bls
+          git add ./bls/lib/ios -f
+          git add ./bls/lib/iossimulator -f 
 
-          git add ./bls/lib/iossimulator -f && git commit -m "fix(release): added libs for ios simulator"  && git push
+          git checkout .
+          git status . -s | grep "M\|A" | wc -l git commit -m "fix(release): added libs for ios/ios simulator"  && git push
 
   build-windows:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,56 +38,11 @@ jobs:
           git config user.email github-actions@github.com
           git push --set-upstream origin release
 
-  build-windows:
-    runs-on: windows-latest
-    needs: create-branch
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ^1.20
-
-      - name: Install MSYS2
-        uses: msys2/setup-msys2@v2
-        with:
-          update: true
-          msystem: MINGW64
-          install: base-devel git gcc make python3 # mingw-w64-x86_64-clang
-
-      - name: Build windows
-        # shell: msys2 {0}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        run: |
-          git pull && git checkout release
-          git submodule update --init --recursive
-
-          gcc --version
-          python3 --version
-
-          git checkout .
-          if (Test-Path "./bls/lib/windows/amd64") {
-            Remove-Item "./bls/lib/windows/amd64" -Recurse -Force
-          }
-          make clean
-          # make -j # ar gives an error for some reason, so use the followings:
-
-          md "./bls/lib/windows/amd64"
-
-          make -C ./src/bls -f Makefile.onelib LIB_DIR=./
-          cp ./src/bls/libbls384_256.a ./bls/lib/windows/amd64/libbls384_256.a
-
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add ./bls/lib/windows -f && git commit -m "fix(release): added libs for windows"  && git push
-
+  
 
   build-linux:
     runs-on: ubuntu-latest
-    needs: build-windows
+    needs: create-branch
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -219,9 +174,56 @@ jobs:
           make ios_simulator
           git add ./bls/lib/iossimulator -f && git commit -m "fix(release): added libs for ios simulator"  && git push
 
+  build-windows:
+    runs-on: windows-latest
+    needs: build-macos
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.20
+
+      - name: Install MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          msystem: MINGW64
+          install: base-devel git gcc make python3 # mingw-w64-x86_64-clang
+
+      - name: Build windows
+        # shell: msys2 {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        run: |
+          git pull && git checkout release
+          git submodule update --init --recursive
+
+          gcc --version
+          python3 --version
+
+          git checkout .
+          if (Test-Path "./bls/lib/windows/amd64") {
+            Remove-Item "./bls/lib/windows/amd64" -Recurse -Force
+          }
+          make clean
+          # make -j # ar gives an error for some reason, so use the followings:
+
+          md "./bls/lib/windows/amd64"
+
+          make -C ./src/bls -f Makefile.onelib LIB_DIR=./
+          cp ./src/bls/libbls384_256.a ./bls/lib/windows/amd64/libbls384_256.a
+
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add ./bls/lib/windows -f && git commit -m "fix(release): added libs for windows"  && git push
+
+
   create-release:
     runs-on: ubuntu-latest
-    needs: build-macos
+    needs: build-windows
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           git pull
           git checkout release 2>/dev/null || git checkout -b release
-          git merge master -q -m "chore(git): merged latest master"
+          git merge origin/master -q -m "chore(git): merged latest master"
           git submodule update --init --recursive
 
           git config user.name github-actions
@@ -203,7 +203,7 @@ jobs:
           [ -d ./bls/lib/ios ] && rm -rf ./bls/lib/ios
           [ -d ./bls/lib/iossimulator ] && rm -rf ./bls/lib/iossimulator
           make clean
-          
+
           mkdir -p ./bls/lib/ios
           mkdir -p ./bls/lib/iossimulator
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           # make -j # ar gives an error for some reason, so use the followings:
 
           make -C ./src/bls -f Makefile.onelib LIB_DIR=./
-          cp ./src/bls/libbls384_256.a ./bls/lib/windows/amd64/
+          cp ./src/bls/libbls384_256.a ./bls/lib/windows/amd64/libbls384_256.a
 
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git pull && git checkout release
+          git checkout . && git pull && git checkout release
           git submodule update --init --recursive
 
           gcc --version
@@ -120,7 +120,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git pull && git checkout release
+          git checkout . && git pull && git checkout release
           git submodule update --init --recursive
           
           sudo apt install nasm
@@ -139,7 +139,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git pull && git checkout release
+          git checkout . && git pull && git checkout release
           git submodule update --init --recursive
 
           [ -d ./bls/lib/android/ ] && rm -rf ./bls/lib/android/
@@ -169,7 +169,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git pull && git checkout release
+          git checkout . && git pull && git checkout release
           git submodule update --init --recursive
 
           brew install nasm
@@ -189,7 +189,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git pull && git checkout release
+          git checkout . && git pull && git checkout release
           git submodule update --init --recursive
 
           [ -d ./bls/lib/ios ] && rm -rf ./bls/lib/ios

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,9 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
+          rm -rf ./obj
+          git restore ./src/bls
+
           git add ./bls/lib/ -f && git commit -m "fix(release): added libs for linux/android" && git push
          
   build-macos:
@@ -128,6 +131,9 @@ jobs:
 
           git config user.name github-actions
           git config user.email github-actions@github.com
+          
+          rm -rf ./obj
+          git restore ./src/bls
 
           git add ./bls/lib/darwin/ -f && git commit -m "fix(release): added libs for darwin"  && git push
 
@@ -150,9 +156,17 @@ jobs:
           git config user.email github-actions@github.com
 
           make ios
+
+          rm -rf ./obj
+          git restore ./src/bls
+
           git add ./bls/lib/ios -f && git commit -m "fix(release): added libs for ios"  && git push
 
           make ios_simulator
+
+          rm -rf ./obj
+          git restore ./src/bls
+
           git add ./bls/lib/iossimulator -f && git commit -m "fix(release): added libs for ios simulator"  && git push
 
   build-windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,12 +127,15 @@ jobs:
 
           git checkout .
           [ -d ./bls/lib/linux/ ] && rm -rf ./bls/lib/linux/
+
           make clean
 
           mkdir -p ./bls/lib/linux/
 
+          git status .
           make CXX=clang++
 
+          git status .
           git config user.name github-actions
           git config user.email github-actions@github.com
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Checkout branch
         shell: msys2 {0}
         run: |
-          git pull && git checkout "$BRANCH_NAME" && git pull
+          git pull && git checkout release && git pull
           git submodule update --init --recursive
 
       - name: Build windows
@@ -114,7 +114,7 @@ jobs:
 
       - name: Checkout branch
         run: |
-          git pull && git checkout "$BRANCH_NAME" && git pull
+          git pull && git checkout release && git pull
           git submodule update --init --recursive
 
       - name: Build linux
@@ -160,7 +160,7 @@ jobs:
 
       - name: Checkout branch
         run: |
-          git pull && git checkout "$BRANCH_NAME" && git pull
+          git pull && git checkout release && git pull
           git submodule update --init --recursive
 
       - name: Build darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        run: gh release create "release-${{ github.event.inputs.version }}" -t "${{ github.event.inputs.version }}" --target "${{ env.hash }}"
+        run: gh release create release -t "${{ github.event.inputs.version }}" --target "${{ env.hash }}"
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,6 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git push --set-upstream origin release
-
-  
-
   build-linux:
     runs-on: ubuntu-latest
     needs: create-branch
@@ -98,7 +95,7 @@ jobs:
           rm -rf ./obj
           git restore ./src/bls
 
-          git add ./bls/lib/ -f && git commit -m "fix(release): added libs for linux/android" && git push
+          git add ./bls/lib/ -f && git commit -m "fix(release): added libs for linux/android"  2>/dev/null && git push
          
   build-macos:
     runs-on: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git checkout release || git checkout -b release
+          git checkout -B release
           git submodule update --init --recursive
 
           git config user.name github-actions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,12 @@ jobs:
 
           gcc --version
           python3 --version
+
+          [ -d ./bls/lib/windows/amd64 ] && rm -rf ./bls/lib/windows/amd64
           make clean
           # make -j # ar gives an error for some reason, so use the followings:
           mkdir -p ./bls/lib/windows/amd64
+
           make -C ./src/bls -f Makefile.onelib LIB_DIR=./
           cp ./src/bls/libbls384_256.a ./bls/lib/windows/amd64/
 
@@ -117,7 +120,10 @@ jobs:
           git submodule update --init --recursive
           
           sudo apt install nasm
+          [ -d ./bls/lib/linux/ ] && rm -rf ./bls/lib/linux/
           make clean
+          mkdir -p ./bls/lib/linux/
+
           make CXX=clang++
 
           git config user.name github-actions
@@ -133,7 +139,10 @@ jobs:
           git pull && git checkout release && git pull
           git submodule update --init --recursive
 
+          [ -d ./bls/lib/android/ ] && rm -rf ./bls/lib/android/
           make clean
+          mkdir -p ./bls/lib/android/
+
           make android
 
           git config user.name github-actions
@@ -162,7 +171,11 @@ jobs:
           git submodule update --init --recursive
 
           brew install nasm
+
+          [ -d ./bls/lib/darwin/ ] && rm -rf ./bls/lib/darwin/
           make clean
+          mkdir -p ./bls/lib/darwin/
+
           make
 
           git config user.name github-actions
@@ -178,7 +191,11 @@ jobs:
           git pull && git checkout release && git pull
           git submodule update --init --recursive
 
+          [ -d ./bls/lib/ios ] && rm -rf ./bls/lib/ios
+          [ -d ./bls/lib/iossimulator ] && rm -rf ./bls/lib/iossimulator
           make clean
+          mkdir -p ./bls/lib/ios
+          mkdir -p ./bls/lib/iossimulator
 
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
+          git pull
           git checkout release 2>/dev/null || git checkout -b release
           git submodule update --init --recursive
 
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git pull
           git push --set-upstream origin release
 
   build-windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          (git checkout release 2>/dev/null && git pull) || git checkout -b release
+          git checkout release 2>/dev/null || git checkout -b release
           git submodule update --init --recursive
 
           git config user.name github-actions
           git config user.email github-actions@github.com
+          git pull
           git push --set-upstream origin release
 
   build-windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,7 @@ jobs:
           
           sudo apt install nasm
 
-          git checkout .
           [ -d ./bls/lib/linux/ ] && rm -rf ./bls/lib/linux/
-
           make clean
 
           mkdir -p ./bls/lib/linux/
@@ -90,8 +88,13 @@ jobs:
           git config user.email github-actions@github.com
 
           git add ./bls/lib/linux -f 
-          git checkout . 
-          git status . -s | grep "M\|A" | wc -l && git commit -m "fix(release): added libs for linux" && git push
+
+          changes=$(git diff --staged --numstat | wc -l)
+          if [[ $changes -gt 0 ]]
+          then
+            git commit -m "fix(release): added libs for linux" 
+            git push
+          fi
 
       - name: Build android
         env:
@@ -99,9 +102,7 @@ jobs:
         run: |
           git pull && git checkout release
 
-          git checkout .
           [ -d ./bls/lib/android/ ] && rm -rf ./bls/lib/android/
-
           make clean
 
           mkdir -p ./bls/lib/android/
@@ -112,10 +113,13 @@ jobs:
           git config user.email github-actions@github.com
 
           git add ./bls/lib/android/ -f 
-          git checkout . 
-          git status . -s | grep "M\|A" | wc -l && git commit -m "fix(release): added libs for android" && git push
-                  
-
+ 
+          changes=$(git diff --staged --numstat | wc -l)
+          if [[ $changes -gt 0 ]]
+          then
+            git commit -m "fix(release): added libs for android" 
+            git push
+          fi
   build-macos:
     runs-on: macos-latest
     needs: build-linux
@@ -152,7 +156,8 @@ jobs:
           changes=$(git diff --staged --numstat | wc -l)
           if [[ $changes -gt 0 ]]
           then
-            git commit -m "fix(release): added libs for darwin"  && git push
+            git commit -m "fix(release): added libs for darwin"
+            git push
           fi
 
       - name: Build ios
@@ -162,7 +167,6 @@ jobs:
           git pull && git checkout release
           git submodule update --init --recursive
 
-          git checkout . 
           [ -d ./bls/lib/ios ] && rm -rf ./bls/lib/ios
           [ -d ./bls/lib/iossimulator ] && rm -rf ./bls/lib/iossimulator
           make clean
@@ -179,8 +183,12 @@ jobs:
           git add ./bls/lib/ios -f
           git add ./bls/lib/iossimulator -f 
 
-          git checkout .
-          git status . -s | grep "M\|A" | wc -l git commit -m "fix(release): added libs for ios/ios simulator"  && git push
+          changes=$(git diff --staged --numstat | wc -l)
+          if [[ $changes -gt 0 ]]
+          then
+            git commit -m "fix(release): added libs for ios/ios simulator"
+            git push
+          fi
 
   build-windows:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           git pull
           git checkout release 2>/dev/null || git checkout -b release
+          git merge master -q -m "chore(git): merged latest master"
           git submodule update --init --recursive
 
           git config user.name github-actions
@@ -61,21 +62,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git checkout . && git pull && git checkout release
+          git pull && git checkout release
           git submodule update --init --recursive
 
           gcc --version
           python3 --version
 
-
+          git checkout .
           if (Test-Path "./bls/lib/windows/amd64") {
             Remove-Item "./bls/lib/windows/amd64" -Recurse -Force
           }
-
-          md "./bls/lib/windows/amd64"
-       
           make clean
           # make -j # ar gives an error for some reason, so use the followings:
+
+          md "./bls/lib/windows/amd64"
 
           make -C ./src/bls -f Makefile.onelib LIB_DIR=./
           cp ./src/bls/libbls384_256.a ./bls/lib/windows/amd64/libbls384_256.a
@@ -120,12 +120,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git checkout . && git pull && git checkout release
+          git pull && git checkout release
           git submodule update --init --recursive
           
           sudo apt install nasm
+
+          git checkout .
           [ -d ./bls/lib/linux/ ] && rm -rf ./bls/lib/linux/
           make clean
+
           mkdir -p ./bls/lib/linux/
 
           make CXX=clang++
@@ -139,11 +142,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git checkout . && git pull && git checkout release
+          git pull && git checkout release
           git submodule update --init --recursive
 
+          git checkout . 
           [ -d ./bls/lib/android/ ] && rm -rf ./bls/lib/android/
           make clean
+
           mkdir -p ./bls/lib/android/
 
           make android
@@ -169,13 +174,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git checkout . && git pull && git checkout release
+          git pull && git checkout release
           git submodule update --init --recursive
 
           brew install nasm
 
+          git checkout . 
           [ -d ./bls/lib/darwin/ ] && rm -rf ./bls/lib/darwin/
           make clean
+
           mkdir -p ./bls/lib/darwin/
 
           make
@@ -189,12 +196,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git checkout . && git pull && git checkout release
+          git pull && git checkout release
           git submodule update --init --recursive
 
+          git checkout . 
           [ -d ./bls/lib/ios ] && rm -rf ./bls/lib/ios
           [ -d ./bls/lib/iossimulator ] && rm -rf ./bls/lib/iossimulator
           make clean
+          
           mkdir -p ./bls/lib/ios
           mkdir -p ./bls/lib/iossimulator
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git checkout release 2>/dev/null || git checkout -b release
+          (git checkout release 2>/dev/null && git pull) || git checkout -b release
           git submodule update --init --recursive
 
           git config user.name github-actions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,23 +79,43 @@ jobs:
 
           git checkout .
           [ -d ./bls/lib/linux/ ] && rm -rf ./bls/lib/linux/
-          [ -d ./bls/lib/android/ ] && rm -rf ./bls/lib/android/
 
           make clean
 
           mkdir -p ./bls/lib/linux/
-          mkdir -p ./bls/lib/android/
 
           make CXX=clang++
+
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+          git add ./bls/lib/linux -f 
+          git checkout . 
+          git status . -s | grep "M\|A" && git commit -m "fix(release): added libs for linux" && git push
+
+      - name: Build android
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        run: |
+          git pull && git checkout release
+
+          git checkout .
+          [ -d ./bls/lib/android/ ] && rm -rf ./bls/lib/android/
+
+          make clean
+
+          mkdir -p ./bls/lib/android/
+
           make android
 
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          git add ./bls/lib/ -f 
+          git add ./bls/lib/android/ -f 
           git checkout . 
-          git status . -s | grep "M\|A" && git commit -m "fix(release): added libs for linux/android" && git push
-         
+          git status . -s | grep "M\|A" && git commit -m "fix(release): added libs for android" && git push
+                  
+
   build-macos:
     runs-on: macos-latest
     needs: build-linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,11 @@ jobs:
           python3 --version
 
 
-          if (Test-Path "bls/lib/windows/amd64") {
-            Remove-Item "bls/lib/windows/amd64" -Recurse -Force
+          if (Test-Path "./bls/lib/windows/amd64") {
+            Remove-Item "./bls/lib/windows/amd64" -Recurse -Force
           }
+
+          md "./bls/lib/windows/amd64"
        
           make clean
           # make -j # ar gives an error for some reason, so use the followings:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,10 +67,13 @@ jobs:
           gcc --version
           python3 --version
 
-          [ -d ./bls/lib/windows/amd64 ] && rm -rf ./bls/lib/windows/amd64
+
+          if (Test-Path "bls/lib/windows/amd64") {
+            Remove-Item "bls/lib/windows/amd64" -Recurse -Force
+          }
+       
           make clean
           # make -j # ar gives an error for some reason, so use the followings:
-          mkdir -p ./bls/lib/windows/amd64
 
           make -C ./src/bls -f Makefile.onelib LIB_DIR=./
           cp ./src/bls/libbls384_256.a ./bls/lib/windows/amd64/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git checkout -B release
+          git checkout release 2>/dev/null || git checkout -b release
           git submodule update --init --recursive
 
           git config user.name github-actions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        run: gh release create release -t "${{ github.event.inputs.version }}" --target "${{ env.hash }}"
+        run: gh release create "${{ github.event.inputs.version }}" -t "${{ github.event.inputs.version }}" --target "release" --latest
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git checkout -b "$BRANCH_NAME"
+          git checkout release || git checkout -b release
           git submodule update --init --recursive
 
           git config user.name github-actions
@@ -207,7 +207,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
-          git pull && git checkout "$BRANCH_NAME" && git pull
+          git pull && git checkout release && git pull
           git submodule update --init --recursive
           git branch -av
           git rev-parse HEAD
@@ -223,16 +223,5 @@ jobs:
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-  delete-branch:
-    runs-on: ubuntu-latest
-    needs: [ create-release ]
-    if: always()
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Delete branch
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git pull && git push origin -d refs/origin/"$BRANCH_NAME"
+
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,14 +88,11 @@ jobs:
           make CXX=clang++
           make android
 
-          git status .
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          rm -rf ./obj
-          git restore ./src/bls
-
-          git add ./bls/lib/ -f && git commit -m "fix(release): added libs for linux/android"  2>/dev/null && git push
+          git add ./bls/lib/ -f 
+          git status . -s | grep "M\|A" && git commit -m "fix(release): added libs for linux/android" && git push
          
   build-macos:
     runs-on: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add ./bls/lib/windows -f
-          git commit -m "fix(release): added libs for windows"
-          git push
+          git commit -m "fix(release): added libs for windows"  && git push
 
 
   build-linux:
@@ -129,9 +128,8 @@ jobs:
           git config user.email github-actions@github.com
 
           git add ./bls/lib/linux/ -f
-          git commit -m "fix(release): added libs for linux"
-          git push
-
+          git commit -m "fix(release): added libs for linux" && git push
+         
       - name: Build android
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
@@ -143,8 +141,7 @@ jobs:
           git config user.email github-actions@github.com
 
           git add ./bls/lib/android/ -f
-          git commit -m "fix(release): added libs for android"
-          git push
+          git commit -m "fix(release): added libs for android"  && git push
 
   build-macos:
     runs-on: macos-latest
@@ -175,8 +172,7 @@ jobs:
           git config user.email github-actions@github.com
 
           git add ./bls/lib/darwin/ -f
-          git commit -m "fix(release): added libs for darwin"
-          git push
+          git commit -m "fix(release): added libs for darwin"  && git push
 
       - name: Build ios
         env:
@@ -193,8 +189,7 @@ jobs:
           make ios_simulator
           git add ./bls/lib/iossimulator -f
 
-          git commit -m "fix(release): added libs for ios/ios simulator"
-          git push
+          git commit -m "fix(release): added libs for ios/ios simulator"  && git push
 
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,7 @@ jobs:
 
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add ./bls/lib/windows -f
-          git commit -m "fix(release): added libs for windows"  && git push
+          git add ./bls/lib/windows -f && git commit -m "fix(release): added libs for windows"  && git push
 
 
   build-linux:
@@ -134,8 +133,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          git add ./bls/lib/linux/ -f
-          git commit -m "fix(release): added libs for linux" && git push
+          git add ./bls/lib/linux/ -f && git commit -m "fix(release): added libs for linux" && git push
          
       - name: Build android
         env:
@@ -153,8 +151,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          git add ./bls/lib/android/ -f
-          git commit -m "fix(release): added libs for android"  && git push
+          git add ./bls/lib/android/ -f && git commit -m "fix(release): added libs for android"  && git push
 
   build-macos:
     runs-on: macos-latest
@@ -186,8 +183,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          git add ./bls/lib/darwin/ -f
-          git commit -m "fix(release): added libs for darwin"  && git push
+          git add ./bls/lib/darwin/ -f && git commit -m "fix(release): added libs for darwin"  && git push
 
       - name: Build ios
         env:
@@ -206,12 +202,10 @@ jobs:
           git config user.email github-actions@github.com
 
           make ios
-          git add ./bls/lib/ios -f
+          git add ./bls/lib/ios -f && git commit -m "fix(release): added libs for ios"  && git push
 
           make ios_simulator
-          git add ./bls/lib/iossimulator -f
-
-          git commit -m "fix(release): added libs for ios/ios simulator"  && git push
+          git add ./bls/lib/iossimulator -f && git commit -m "fix(release): added libs for ios simulator"  && git push
 
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           install: base-devel git gcc make python3 # mingw-w64-x86_64-clang
 
       - name: Build windows
-        shell: msys2 {0}
+        # shell: msys2 {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |

--- a/bls/link.go
+++ b/bls/link.go
@@ -5,9 +5,9 @@ package bls
 
 /*
 #cgo LDFLAGS:-lbls384_256 -lstdc++ -lm
-#cgo android,arm64 LDFLAGS:-L${SRCDIR}/lib/linux/arm64
+#cgo android,arm64 LDFLAGS:-L${SRCDIR}/lib/android/arm64-v8a
 #cgo android,arm LDFLAGS:-L${SRCDIR}/lib/android/armeabi-v7a
-#cgo android,amd64 LDFLAGS:-L${SRCDIR}/lib/linux/amd64
+#cgo android,amd64 LDFLAGS:-L${SRCDIR}/lib/android/x86_64
 #cgo linux,amd64 LDFLAGS:-L${SRCDIR}/lib/linux/amd64
 #cgo linux,arm64 LDFLAGS:-L${SRCDIR}/lib/linux/arm64
 #cgo linux,mipsle LDFLAGS:-L${SRCDIR}/lib/linux/mipsel


### PR DESCRIPTION
## Fixes
- used fixed branch to create release, and never delete it

```
# github.com/0chain/gosdk/zcncore/sample.test
/usr/local/go/pkg/tool/darwin_amd64/link: running clang failed: exit status 1
ld: warning: directory not found for option '-L/Users/geax/code/go/pkg/mod/github.com/herumi/bls-go-binary@v1.30.4/bls/lib/darwin/amd64'
ld: library not found for -lbls384_256
clang: error: linker command failed with exit code 1 (use -v to see invocation)

# github.com/0chain/gosdk/zcncore.test
/usr/local/go/pkg/tool/darwin_amd64/link: running clang failed: exit status 1
ld: warning: directory not found for option '-L/Users/geax/code/go/pkg/mod/github.com/herumi/bls-go-binary@v1.30.4/bls/lib/darwin/amd64'
ld: library not found for -lbls384_256
clang: error: linker command failed with exit code 1 (use -v to see invocation)

# github.com/0chain/gosdk/zcnswap/utils.test
/usr/local/go/pkg/tool/darwin_amd64/link: running clang failed: exit status 1
ld: warning: directory not found for option '-L/Users/geax/code/go/pkg/mod/github.com/herumi/bls-go-binary@v1.30.4/bls/lib/darwin/amd64'
ld: library not found for -lbls384_256
clang: error: linker command failed with exit code 1 (use -v to see invocation)

# github.com/0chain/gosdk/zmagmacore/magmasc.test
/usr/local/go/pkg/tool/darwin_amd64/link: running clang failed: exit status 1
ld: warning: directory not found for option '-L/Users/geax/code/go/pkg/mod/github.com/herumi/bls-go-binary@v1.30.4/bls/lib/darwin/amd64'
ld: library not found for -lbls384_256
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```